### PR TITLE
Base element and weirdness

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -4,14 +4,14 @@ const by: typeof selwd.By = selwd.By;
 import {getBrowser} from "./index";
 import Locator from "./locator";
 
-export class BaseElement {
+export default class BaseElement {
     private _locator: Locator;
 
     constructor(locator: Locator) {
         this._locator = locator;
     }
 
-    click(): selwd.promise.Promise<void> {
+    public click(): selwd.promise.Promise<void> {
         return getBrowser().findElement(by.id(this._locator.id)).click();
     }
 

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -1,3 +1,3 @@
 export default class Locator {
-    id: string;
+    public id: string;
 }

--- a/src/span.ts
+++ b/src/span.ts
@@ -1,13 +1,8 @@
-import {getBrowser} from "./index";
-import * as selwd from "selenium-webdriver";
-const by: typeof selwd.By = selwd.By;
+import BaseElement from "./base";
+import Locator from "./locator";
 
-export class Span {
-    private _locator: any;
-    constructor(locator: any) {
-        this._locator = locator;
-    }
-    get text(): any {
-        return getBrowser().findElement(by.id(this._locator.id)).getText();  //<== De-promisify
+export class Span extends BaseElement {
+    constructor(locator: Locator) {
+        super(locator);
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,8 @@
         "src/browser.ts",
         "src/builderFactory.spec.ts",
         "src/builderFactory.ts",
+        "src/locator.ts",
+        "src/base.ts",
         "src/button.ts",
         "src/index.ts",
         "src/person.spec.ts",

--- a/typings.json
+++ b/typings.json
@@ -5,7 +5,6 @@
     "tape": "github:DefinitelyTyped/DefinitelyTyped/tape/tape.d.ts#221df9ad820d0b2aa010d328c4bab06c8d69ac1f"
   },
   "dependencies": {
-    "chai": "registry:npm/chai#3.5.0+20160328084239",
     "es6-promise": "github:typings/typed-es6-promise#94aac67ef7a14a8de8e9e1d3c1f9a26caa0d9fb1"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,11 +1,11 @@
 {
   "ambientDependencies": {
-    "chai": "registry:dt/chai#3.4.0+20160317120654",
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#221df9ad820d0b2aa010d328c4bab06c8d69ac1f",
     "selenium-webdriver": "github:DefinitelyTyped/DefinitelyTyped/selenium-webdriver/selenium-webdriver.d.ts#a83677ed13add14c2ab06c7325d182d0ba2784ea",
     "tape": "github:DefinitelyTyped/DefinitelyTyped/tape/tape.d.ts#221df9ad820d0b2aa010d328c4bab06c8d69ac1f"
   },
   "dependencies": {
+    "chai": "registry:npm/chai#3.5.0+20160328084239",
     "es6-promise": "github:typings/typed-es6-promise#94aac67ef7a14a8de8e9e1d3c1f9a26caa0d9fb1"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,6 @@
 {
   "ambientDependencies": {
+    "chai": "registry:dt/chai#3.4.0+20160317120654",
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#221df9ad820d0b2aa010d328c4bab06c8d69ac1f",
     "selenium-webdriver": "github:DefinitelyTyped/DefinitelyTyped/selenium-webdriver/selenium-webdriver.d.ts#a83677ed13add14c2ab06c7325d182d0ba2784ea",
     "tape": "github:DefinitelyTyped/DefinitelyTyped/tape/tape.d.ts#221df9ad820d0b2aa010d328c4bab06c8d69ac1f"


### PR DESCRIPTION
Alright, so I tried to get span to inherit from the base element but I wasn't able to run the cukes, mostly (I think) because Atom rewriting my tsconfig like an butthole. 

Anyway, I wanted to get @kwpeters' opinion on some of the stuff that I've highlighted in this PR. Mostly that I don't know if I really need the `public` keyword before `click()` in my `BaseElement` class or the `public` before `id` in my locator class. 

Also, am I doing the export correctly? Should I use non-default exports instead?

Like I said, I wasn't able to run the cukes, @kmckee, can I get some input on that? Does your Atom do weird things with your `tsconfig.json` too? Does it stop you from running the cukes?
